### PR TITLE
Upgrade Ruby to fix archived Debian package index

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ EXPOSE 9292
 
 RUN apt-get update && apt-get install -qq -y --no-install-recommends \
          build-essential \
-         libmysqlclient-dev
+         default-libmysqlclient-dev
 
 RUN mkdir -p /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ruby:2.4.0
+FROM ruby:2.4.5
 
 MAINTAINER Kate Lynch <katherly@upenn.edu>
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.4.0'
+ruby '2.4.5'
 
 gem 'sinatra'
 gem 'mysql2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ DEPENDENCIES
   tux
 
 RUBY VERSION
-   ruby 2.4.0p0
+   ruby 2.4.5p335
 
 BUNDLED WITH
-   1.16.4
+   1.17.3


### PR DESCRIPTION
Docker builds are failing due to [Debian Jessie being archived](https://github.com/debuerreotype/docker-debian-artifacts/issues/66#issuecomment-476648047). Upgrading to a newer patch for Ruby 2.4 and updating the MySQL package index to a newer version fixes things right up. 💪🏻