### PR TITLE
Use image hosted on Quay.io

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+*.example
+.circleci
+.dockerignore
+.git
+.gitignore
+.gitleaks.toml
+Dockerfile
+docker-compose.yml
+LICENSE
+README.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     restart: 'unless-stopped'
     depends_on:
       - 'db'
-    image: 'marmite:latest'
+    image: 'quay.io/upennlibraries/marmite:afd4aa3'
     ports:
       - '9292:9292'
     env_file:


### PR DESCRIPTION
We can now deploy the image hosted at the [Quay.io](https://quay.io/repository/upennlibraries/marmite) registry. ⛵️ We can deploy by Git commit hash for now until we figure out if we want to use a different versioning scheme.

I also added a `.dockerignore` file to keep the `.git` directory and some other stuff out of the final built image. ⛔️:octocat: 